### PR TITLE
 adding google nameservers into the DHCP push

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -46,6 +46,8 @@ dh dh.pem
 keepalive 10 60
 persist-key
 persist-tun
+push "dhcp-option DNS 8.8.8.8"
+push "dhcp-option DNS 8.8.4.4"
 
 proto udp
 port 1194


### PR DESCRIPTION
When i used this openvpn docker, I was not able to browse as the name resolutions failed..

I compared this against my own openvpn setup and found that nameservers dhcp push settings were not there and hence added them on my own fork.

If this looks good , please pull.
