### PR TITLE
Server on 443 should also push DNS options

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -28,6 +28,8 @@ dh dh.pem
 keepalive 10 60
 persist-key
 persist-tun
+push "dhcp-option DNS 8.8.8.8"
+push "dhcp-option DNS 8.8.4.4"
 
 proto tcp-server
 port 443


### PR DESCRIPTION
Any reason why these settings are not duplicated on both servers?
