### PR TITLE
Increase DH key length to 1024 bits due to Logjam (CVE-2015-4000)

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -10,7 +10,7 @@ cd /etc/openvpn
 # This file tells `serveconfig` that there is a config there
 touch placeholder
 [ -f dh.pem ] ||
-    openssl dhparam -out dh.pem 512
+    openssl dhparam -out dh.pem 1024
 [ -f key.pem ] ||
     openssl genrsa -out key.pem 2048
 chmod 600 key.pem


### PR DESCRIPTION
The latest versions of openssl will reject connections if the DH parameter is < 768 bits (and will increase to 1024 at some point in the future).

In order to support the latest version of software (Tunnelblick 3.5.1+ for example) this increases the DH key generation to 1024 bits.