### PR TITLE
Update Ubuntu to 20.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 RUN apt-get update -q
 RUN apt-get install -qy openvpn iptables socat curl
 ADD ./bin /usr/local/sbin

--- a/bin/run
+++ b/bin/run
@@ -10,7 +10,7 @@ cd /etc/openvpn
 # This file tells `serveconfig` that there is a config there
 touch placeholder
 [ -f dh.pem ] ||
-    openssl dhparam -out dh.pem 1024
+    openssl dhparam -out dh.pem 2048
 [ -f key.pem ] ||
     openssl genrsa -out key.pem 2048
 chmod 600 key.pem


### PR DESCRIPTION
Changes:
- updated Ubuntu to 20.04 LTS
- increased DH size from 1024 to 2048 (for resolving issue ```OpenSSL: error:1408518A:SSL routines:ssl3_ctx_ctrl:dh key too small```)